### PR TITLE
Add social app detection utilities and device selection enhancements

### DIFF
--- a/apk_actions.sh
+++ b/apk_actions.sh
@@ -30,22 +30,22 @@ list_apks() {
 
 filter_social_apps() {
     check_device_alive
-    require_file "$OUTDIR/apk_list.csv" || return 1
-
-    SOCIALFILE="$OUTDIR/social_apps.csv"
     log_info "Filtering social media apps..."
-    write_csv_header "$SOCIALFILE" "APK_Path,Package"
 
-    for keyword in "${SOCIAL_APPS[@]}"; do
-        grep -i "$keyword" "$OUTDIR/apk_list.csv" >> "$SOCIALFILE"
-    done
+    bash "$SCRIPT_DIR/find_social_apps.sh" --device "$DEVICE" >>"$LOGFILE" 2>&1
 
-    COUNT=$(($(wc -l < "$SOCIALFILE") - 1))
-    if [ $COUNT -gt 0 ]; then
-        log_info "Found $COUNT social apps → $SOCIALFILE"
+    DEVICE_OUT="$OUTDIR/$DEVICE"
+    LOCAL_SOCIALFILE="$DEVICE_OUT/social_apps_found.csv"
+
+    if [ -f "$LOCAL_SOCIALFILE" ]; then
+        COUNT=$(($(wc -l < "$LOCAL_SOCIALFILE") - 1))
+        if [ $COUNT -gt 0 ]; then
+            log_info "Found $COUNT social apps → $LOCAL_SOCIALFILE"
+        else
+            log_warn "No social media apps found."
+        fi
     else
-        log_warn "No social media apps found."
-        rm -f "$SOCIALFILE"
+        log_warn "Social app scan failed or produced no output."
     fi
 }
 

--- a/config.sh
+++ b/config.sh
@@ -52,15 +52,23 @@ VERBOSE_LOG=false
 #####################
 # Canonical package filters for social media apps
 SOCIAL_APPS=(
+    # Core platforms
     "com.facebook.katana"      # Facebook
     "com.facebook.orca"        # Messenger
     "com.instagram.android"    # Instagram
     "com.twitter.android"      # Twitter / X
+    "com.twitter.android.lite" # Twitter Lite
     "com.zhiliaoapp.musically" # TikTok
     "com.ss.android.ugc.trill" # TikTok (alt)
     "com.snapchat.android"     # Snapchat
     "com.whatsapp"             # WhatsApp
+    "com.whatsapp.w4b"         # WhatsApp Business
     "org.telegram.messenger"   # Telegram
+    "com.facebook.appmanager"  # Facebook App Manager (system)
+    "com.facebook.services"    # Facebook Services (system)
+    "com.facebook.system"      # Facebook Installer (system)
+
+    # Other popular social/messaging apps
     "com.reddit.frontpage"     # Reddit
     "com.linkedin.android"     # LinkedIn
     "com.discord"              # Discord

--- a/find_social_apps.sh
+++ b/find_social_apps.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Script: find_social_apps.sh
+# Purpose: Enumerate packages on a device and flag known social apps.
+# Outputs manifest to /output/<device_serial>/social_apps_found.csv
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/display_utils.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+mkdir -p "$DEVICE_OUT/apks" "$TMPDIR"
+SOCIALFILE="$DEVICE_OUT/social_apps_found.csv"
+write_csv_header "$SOCIALFILE" "Package,APK_Path,Detected,SHA256"
+
+TMPLIST="$TMPDIR/${DEVICE}_pkgs.txt"
+adb -s "$DEVICE" shell pm list packages -f 2>/dev/null | sed 's/^package://g' > "$TMPLIST"
+
+found=0
+while IFS=, read -r APK_PATH PKG; do
+    DETECTED="N"
+    for s in "${SOCIAL_APPS[@]}"; do
+        if [[ "$PKG" == "$s" ]]; then
+            DETECTED="Y"
+            break
+        fi
+    done
+
+    if [[ "$DETECTED" == "Y" ]]; then
+        hash=$(adb -s "$DEVICE" shell sha256sum "$APK_PATH" 2>/dev/null | awk '{print $1}')
+        append_csv_row "$SOCIALFILE" "$PKG,$APK_PATH,✔,$hash"
+        print_detected "$PKG"
+        found=1
+        if [ "$PULL_APKS" = true ]; then
+            adb -s "$DEVICE" pull "$APK_PATH" "$DEVICE_OUT/apks/${PKG}.apk" >/dev/null 2>&1 || true
+        fi
+    else
+        if echo "$PKG" | grep -qi -E 'facebook|instagram|tiktok|snap|twitter|whatsapp|telegram|discord'; then
+            hash=$(adb -s "$DEVICE" shell sha256sum "$APK_PATH" 2>/dev/null | awk '{print $1}')
+            append_csv_row "$SOCIALFILE" "$PKG,$APK_PATH,?,$hash"
+            print_unknown "$PKG"
+            found=1
+        fi
+    fi
+
+done < <(awk -F'=' '{print $1","$2}' "$TMPLIST")
+
+rm -f "$TMPLIST"
+
+if [ $found -eq 0 ]; then
+    print_none
+fi

--- a/list_devices.sh
+++ b/list_devices.sh
@@ -3,8 +3,21 @@
 # Provides: list_devices()
 
 list_devices() {
+    local preselect="$1"
     local devices
     local attempts=0
+
+    # If a serial was provided or already set, just return it
+    if [ -n "$preselect" ]; then
+        DEVICE="$preselect"
+        echo "$DEVICE"
+        return 0
+    fi
+
+    if [ -n "$DEVICE" ]; then
+        echo "$DEVICE"
+        return 0
+    fi
 
     # Retry a few times in case the ADB server is still warming up
     while [ $attempts -lt 5 ]; do
@@ -33,7 +46,7 @@ list_devices() {
     done <<< "$devices"
 
     if [ ${#dev_arr[@]} -eq 1 ]; then
-        echo "${dev_arr[0]}"
+        DEVICE="${dev_arr[0]}"
     else
         read -r -p "[?] Select a device number: " choice
         idx=$((choice-1))
@@ -41,6 +54,9 @@ list_devices() {
             echo ""
             return 1
         fi
-        echo "${dev_arr[$idx]}"
+        DEVICE="${dev_arr[$idx]}"
     fi
+
+    export DEVICE
+    echo "$DEVICE"
 }

--- a/utils/display_utils.sh
+++ b/utils/display_utils.sh
@@ -75,6 +75,19 @@ status_info() {
     echo -e "[${CYAN}ℹ${RESET}] ${WHITE}$1${RESET}"
 }
 
+# Social app discovery helpers
+print_detected() {
+    echo -e "${GREEN}[+]${RESET} ${WHITE}Detected social app:${RESET} $1"
+}
+
+print_unknown() {
+    echo -e "${YELLOW}[-]${RESET} ${WHITE}Package found but not in SOCIAL_APPS list:${RESET} $1"
+}
+
+print_none() {
+    echo -e "${RED}[!]${RESET} ${WHITE}No matches found.${RESET}"
+}
+
 #####################
 # SPINNER (for long tasks)
 #####################


### PR DESCRIPTION
## Summary
- extend `SOCIAL_APPS` with system Facebook packages for broader detection
- route menu-based social scan through `find_social_apps.sh` for per-device CSV output

## Testing
- `bash -n config.sh list_devices.sh find_social_apps.sh utils/display_utils.sh apk_actions.sh run.sh`
- `adb version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c8a4a2b083278ca2b86c114b2119