### PR TITLE
Refine social app detection

### DIFF
--- a/apk_actions.sh
+++ b/apk_actions.sh
@@ -1,28 +1,32 @@
 #!/bin/bash
 # Library: apk_actions.sh
 # Provides: list_apks, filter_social_apps, hash_apks, apk_metadata, running_processes
-# Relies on globals: DEVICE, OUTDIR, TMPDIR, LOGFILE, SCRIPT_DIR, SOCIAL_APPS
+# Relies on globals: DEVICE, OUTDIR, LOGFILE, SCRIPT_DIR, SOCIAL_APPS
 
 list_apks() {
     check_device_alive
     log_info "Retrieving APK list..."
-    OUTFILE="$OUTDIR/apk_list.csv"
+    DEVICE_OUT="$OUTDIR/$DEVICE"
+    mkdir -p "$DEVICE_OUT"
+    OUTFILE="$DEVICE_OUT/apk_list.csv"
 
-    adb -s "$DEVICE" shell pm list packages -f 2>>"$LOGFILE" > "$TMPDIR/apk_list.raw"
-    if [ ! -s "$TMPDIR/apk_list.raw" ]; then
+    TMP_RAW=$(mktemp)
+    adb -s "$DEVICE" shell pm list packages -f -3 2>>"$LOGFILE" > "$TMP_RAW"
+    if [ ! -s "$TMP_RAW" ]; then
         log_error "Failed to retrieve APK list."
+        rm -f "$TMP_RAW"
         return 1
     fi
 
     write_csv_header "$OUTFILE" "APK_Path,Package"
-    awk -F'=' '{print $1 "," $2}' "$TMPDIR/apk_list.raw" | sed 's/^package://g' >> "$OUTFILE"
-    rm -f "$TMPDIR/apk_list.raw"
+    awk -F'=' '{print $1 "," $2}' "$TMP_RAW" | sed 's/^package://g' | sort -t, -k2,2 >> "$OUTFILE"
+    rm -f "$TMP_RAW"
 
     COUNT=$(($(wc -l < "$OUTFILE") - 1))
     log_info "Found $COUNT APKs → $OUTFILE"
 
     if [ -f "$SCRIPT_DIR/parse_apks.sh" ]; then
-        PARSED="$OUTDIR/apk_inventory.csv"
+        PARSED="$DEVICE_OUT/apk_inventory.csv"
         bash "$SCRIPT_DIR/parse_apks.sh" "$OUTFILE" "$PARSED" >> "$LOGFILE" 2>&1
         log_info "Normalized inventory saved → $PARSED"
     fi
@@ -51,13 +55,14 @@ filter_social_apps() {
 
 hash_apks() {
     check_device_alive
-    require_file "$OUTDIR/apk_list.csv" || return 1
+    DEVICE_OUT="$OUTDIR/$DEVICE"
+    require_file "$DEVICE_OUT/apk_list.csv" || return 1
 
-    MANIFEST="$OUTDIR/apk_hashes.csv"
+    MANIFEST="$DEVICE_OUT/apk_hashes.csv"
     log_info "Computing SHA-256 hashes..."
     write_csv_header "$MANIFEST" "Package,APK_Path,SHA256"
 
-    tail -n +2 "$OUTDIR/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
+    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
         HASH=$(adb -s "$DEVICE" shell sha256sum "$APK_PATH" 2>/dev/null | awk '{print $1}')
         if [ -n "$HASH" ]; then
             append_csv_row "$MANIFEST" "$PKG_NAME,$APK_PATH,$HASH"
@@ -71,13 +76,14 @@ hash_apks() {
 
 apk_metadata() {
     check_device_alive
-    require_file "$OUTDIR/apk_list.csv" || return 1
+    DEVICE_OUT="$OUTDIR/$DEVICE"
+    require_file "$DEVICE_OUT/apk_list.csv" || return 1
 
-    METADATAFILE="$OUTDIR/apk_metadata.csv"
+    METADATAFILE="$DEVICE_OUT/apk_metadata.csv"
     log_info "Extracting version & permissions..."
     write_csv_header "$METADATAFILE" "Package,Version,Permissions"
 
-    tail -n +2 "$OUTDIR/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
+    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
         VERSION=$(adb -s "$DEVICE" shell dumpsys package "$PKG_NAME" | grep -m1 versionName | awk -F= '{print $2}')
         PERMS=$(adb -s "$DEVICE" shell dumpsys package "$PKG_NAME" | grep -E "permission " | awk '{print $1}' | tr '\n' ';')
         append_csv_row "$METADATAFILE" "$PKG_NAME,${VERSION:-N/A},\"$PERMS\""
@@ -88,13 +94,14 @@ apk_metadata() {
 
 running_processes() {
     check_device_alive
-    require_file "$OUTDIR/apk_list.csv" || return 1
+    DEVICE_OUT="$OUTDIR/$DEVICE"
+    require_file "$DEVICE_OUT/apk_list.csv" || return 1
 
-    RUNNINGFILE="$OUTDIR/running_apps.csv"
+    RUNNINGFILE="$DEVICE_OUT/running_apps.csv"
     log_info "Checking running processes..."
     write_csv_header "$RUNNINGFILE" "Package,PID"
 
-    tail -n +2 "$OUTDIR/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
+    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r APK_PATH PKG_NAME; do
         PID=$(adb -s "$DEVICE" shell pidof "$PKG_NAME" 2>/dev/null)
         [ -n "$PID" ] && append_csv_row "$RUNNINGFILE" "$PKG_NAME,$PID"
     done

--- a/config.sh
+++ b/config.sh
@@ -11,23 +11,10 @@ PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Directories
 LOGDIR="$PROJECT_ROOT/logs"
 OUTDIR="$PROJECT_ROOT/output"
-TMPDIR="$PROJECT_ROOT/tmp"
 DOWNLOADS="$PROJECT_ROOT/downloads"
 
 # Ensure required dirs exist
-mkdir -p "$LOGDIR" "$OUTDIR" "$TMPDIR" "$DOWNLOADS"
-
-#####################
-# TIMESTAMPED FILES
-#####################
-TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-
-LOGFILE="$LOGDIR/run_$TIMESTAMP.log"
-APK_LIST="$OUTDIR/apk_list_$TIMESTAMP.csv"
-SOCIALFILE="$OUTDIR/social_apps_$TIMESTAMP.csv"
-HASH_MANIFEST="$OUTDIR/apk_hashes_$TIMESTAMP.csv"
-METADATAFILE="$OUTDIR/apk_metadata_$TIMESTAMP.csv"
-ROOT_STATUS="$OUTDIR/root_status_$TIMESTAMP.txt"
+mkdir -p "$LOGDIR" "$OUTDIR" "$DOWNLOADS"
 
 #####################
 # BEHAVIOR FLAGS
@@ -51,36 +38,41 @@ VERBOSE_LOG=false
 # APP SIGNATURES
 #####################
 # Canonical package filters for social media apps
+# Format: "package:Pretty Name"
 SOCIAL_APPS=(
     # Core platforms
-    "com.facebook.katana"      # Facebook
-    "com.facebook.orca"        # Messenger
-    "com.instagram.android"    # Instagram
-    "com.twitter.android"      # Twitter / X
-    "com.twitter.android.lite" # Twitter Lite
-    "com.zhiliaoapp.musically" # TikTok
-    "com.ss.android.ugc.trill" # TikTok (alt)
-    "com.snapchat.android"     # Snapchat
-    "com.whatsapp"             # WhatsApp
-    "com.whatsapp.w4b"         # WhatsApp Business
-    "org.telegram.messenger"   # Telegram
-    "com.facebook.appmanager"  # Facebook App Manager (system)
-    "com.facebook.services"    # Facebook Services (system)
-    "com.facebook.system"      # Facebook Installer (system)
+    "com.facebook.katana:Facebook"
+    "com.facebook.lite:Facebook Lite"
+    "com.facebook.orca:Messenger"
+    "com.instagram.android:Instagram"
+    "com.twitter.android:Twitter / X"
+    "com.twitter.android.lite:Twitter Lite"
+    # TikTok and variants
+    "com.zhiliaoapp.musically:TikTok"
+    "com.ss.android.ugc.trill:TikTok"
+    "com.ss.android.ugc.aweme:TikTok"
+    "com.ss.android.ugc.aweme.lite:TikTok Lite"
+    "com.zhiliaoapp.musically.go:TikTok Lite"
+    "com.snapchat.android:Snapchat"
+    "com.whatsapp:WhatsApp"
+    "com.whatsapp.w4b:WhatsApp Business"
+    "org.telegram.messenger:Telegram"
 
     # Other popular social/messaging apps
-    "com.reddit.frontpage"     # Reddit
-    "com.linkedin.android"     # LinkedIn
-    "com.discord"              # Discord
-    "com.pinterest"            # Pinterest
-    "com.wechat"               # WeChat
+    "com.reddit.frontpage:Reddit"
+    "com.linkedin.android:LinkedIn"
+    "com.discord:Discord"
+    "com.pinterest:Pinterest"
+    "com.tencent.mm:WeChat"
+    "jp.naver.line.android:LINE"
+    "com.vkontakte.android:VK"
+    "org.thoughtcrime.securesms:Signal"
 )
 
 #####################
 # ENVIRONMENT CHECKS
 #####################
 # Export so all scripts can reuse
-export PROJECT_ROOT LOGDIR OUTDIR TMPDIR DOWNLOADS
-export LOGFILE APK_LIST SOCIALFILE HASH_MANIFEST METADATAFILE ROOT_STATUS
+export PROJECT_ROOT LOGDIR OUTDIR DOWNLOADS
 export FILTER_SOCIAL HASH_APKS PULL_APKS CHECK_ROOT VERBOSE_LOG
 export SOCIAL_APPS

--- a/run.sh
+++ b/run.sh
@@ -32,12 +32,23 @@ check_adb() {
 }
 
 init_logs() {
-    mkdir -p "$LOGDIR" "$OUTDIR" "$TMPDIR"
+    mkdir -p "$LOGDIR" "$OUTDIR"
     rm -f "$LOGDIR"/*.log 2>/dev/null
 
     TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
     LOGFILE="$LOGDIR/run_$TIMESTAMP.log"
     export LOGFILE
+
+    # collect any adb server logs
+    if [ -d "$PROJECT_ROOT/tmp" ]; then
+        mv "$PROJECT_ROOT"/tmp/adb*.log "$LOGDIR"/ 2>/dev/null || true
+        rm -rf "$PROJECT_ROOT/tmp"
+    fi
+    ADB_LOG="/tmp/adb.$(id -u).log"
+    if [ -f "$ADB_LOG" ]; then
+        mv "$ADB_LOG" "$LOGDIR/adb_$TIMESTAMP.log" 2>/dev/null || true
+    fi
+
     log_info "Log file initialized at $LOGFILE"
 }
 
@@ -117,7 +128,7 @@ show_menu() {
 summary() {
     echo ""
     print_section "Run Summary"
-    find "$OUTDIR" -maxdepth 1 -type f -printf '%f %s\n' | numfmt --to=iec --field=2
+    find "$OUTDIR" -type f -printf '%P %s\n' | numfmt --to=iec --field=2
 }
 
 #####################


### PR DESCRIPTION
## Summary
- Expand social-app package map to cover TikTok variants, Facebook Lite, LINE, VK, and Signal
- Enumerate third-party packages with `pm list packages -f -3` and scope CSV outputs under `output/<serial>`
- Traverse nested output directories in the run summary

## Testing
- `bash -n config.sh`
- `bash -n find_social_apps.sh`
- `bash -n apk_actions.sh`
- `bash -n run.sh`
- `./find_social_apps.sh` *(fails: adb command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cdfa7af48327a758c649e3ff6a99