### PR TITLE
fix: avoid unbound DEVICE variable in list_devices

### DIFF
--- a/list_devices.sh
+++ b/list_devices.sh
@@ -14,7 +14,7 @@ list_devices() {
         return 0
     fi
 
-    if [ -n "$DEVICE" ]; then
+    if [ -n "${DEVICE:-}" ]; then
         echo "$DEVICE"
         return 0
     fi


### PR DESCRIPTION
## Summary
- prevent list_devices from failing under `set -u` when DEVICE is unset

## Testing
- `./run.sh --non-interactive` *(fails: adb not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e5792f4c8327a13065c1e832c443