### PR TITLE
Refactor pipeline and social app detection

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -41,40 +41,48 @@ GENERATE_DERIVED=false
 # APP SIGNATURES
 #####################
 # Canonical package filters for social media apps
-# Format: "package:Pretty Name"
 SOCIAL_APPS=(
     # Core platforms
-    "com.facebook.katana:Facebook"
-    "com.facebook.lite:Facebook Lite"
-    "com.facebook.orca:Messenger"
-    "com.instagram.android:Instagram"
-    "com.twitter.android:Twitter / X"
-    "com.twitter.android.lite:Twitter Lite"
+    com.facebook.katana
+    com.facebook.lite
+    com.facebook.orca
+    com.instagram.android
+    com.twitter.android
+    com.twitter.android.lite
     # TikTok and variants
-    "com.zhiliaoapp.musically:TikTok"
-    "com.ss.android.ugc.trill:TikTok"
-    "com.ss.android.ugc.aweme:TikTok"
-    "com.ss.android.ugc.aweme.lite:TikTok Lite"
-    "com.zhiliaoapp.musically.go:TikTok Lite"
-    "com.snapchat.android:Snapchat"
-    "com.whatsapp:WhatsApp"
-    "com.whatsapp.w4b:WhatsApp Business"
-    "org.telegram.messenger:Telegram"
+    com.zhiliaoapp.musically
+    com.ss.android.ugc.trill
+    com.ss.android.ugc.aweme
+    com.ss.android.ugc.aweme.lite
+    com.zhiliaoapp.musically.go
+    # Messaging and others
+    com.snapchat.android
+    com.whatsapp
+    com.whatsapp.w4b
+    org.telegram.messenger
+    com.reddit.frontpage
+    com.linkedin.android
+    com.discord
+    com.pinterest
+    com.tencent.mm
+    jp.naver.line.android
+    com.vkontakte.android
+    org.thoughtcrime.securesms
+    com.tinder
+    tv.twitch.android.app
+    com.google.android.youtube
+)
 
-    # Other popular social/messaging apps
-    "com.reddit.frontpage:Reddit"
-    "com.linkedin.android:LinkedIn"
-    "com.discord:Discord"
-    "com.pinterest:Pinterest"
-    "com.tencent.mm:WeChat"
-    "jp.naver.line.android:LINE"
-    "com.vkontakte.android:VK"
-    "org.thoughtcrime.securesms:Signal"
+# Preload/support components mapped to social family
+declare -Ag SOCIAL_PRELOADS=(
+    [com.facebook.appmanager]=facebook
+    [com.facebook.services]=facebook
+    [com.facebook.system]=facebook
 )
 
 # Heuristic keywords for social app detection
 SOCIAL_KEYWORDS=(
-    facebook instagram twitter tiktok snapchat whatsapp telegram reddit linkedin discord pinterest wechat line vk signal
+    facebook instagram tiktok snap twitter whatsapp telegram discord reddit linkedin twitch youtube
 )
 
 #####################
@@ -83,4 +91,4 @@ SOCIAL_KEYWORDS=(
 # Export so all scripts can reuse
 export PROJECT_ROOT LOGDIR OUTDIR DOWNLOADS
 export FILTER_SOCIAL HASH_APKS PULL_APKS CHECK_ROOT VERBOSE_LOG GENERATE_DERIVED
-export SOCIAL_APPS SOCIAL_KEYWORDS
+export SOCIAL_APPS SOCIAL_KEYWORDS SOCIAL_PRELOADS

--- a/run.sh
+++ b/run.sh
@@ -1,258 +1,43 @@
 #!/bin/bash
-# Integrated Android APK inventory pipeline
-# Generates per-run output with a single master apps inventory CSV
-
+# Orchestrate device data collection using step scripts
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 source "$SCRIPT_DIR/list_devices.sh"
-# shellcheck source=utils/output_utils.sh
-[ -f "$SCRIPT_DIR/utils/output_utils.sh" ] && source "$SCRIPT_DIR/utils/output_utils.sh"
-# shellcheck source=utils/logging_utils.sh
-[ -f "$SCRIPT_DIR/utils/logging_utils.sh" ] && source "$SCRIPT_DIR/utils/logging_utils.sh"
 
-# Fallback logging helpers if library missing
-log_info(){ echo "[${TZ:+}$(date '+%F %T')] [INFO] $*"; }
-log_warn(){ echo "[${TZ:+}$(date '+%F %T')] [WARN] $*"; }
-log_error(){ echo "[${TZ:+}$(date '+%F %T')] [ERROR] $*" >&2; }
-
-#####################
-# ARGUMENT PARSING
-#####################
-PRESELECT=""
-NON_INTERACTIVE=0 # parsed but currently no interactive menu
+DEVICE_ARG=""
 while [[ ${1-} ]]; do
-  case "$1" in
-    -d|--device) PRESELECT="$2"; shift 2;;
-    --non-interactive) NON_INTERACTIVE=1; shift;;
-    *) shift;;
-  esac
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
 done
 
-#####################
-# DEVICE SELECTION & HEALTH
-#####################
-check_adb(){ command -v adb >/dev/null || { log_error "adb not found"; exit 1; }; }
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-select_device(){
-  DEVICE=$(list_devices "$PRESELECT") || true
-  if [[ -z "${DEVICE:-}" ]]; then
-    log_error "No device selected"; exit 1
-  fi
-  echo "$DEVICE"
-}
+DEVICE_OUT="$OUTDIR/$DEVICE"
+mkdir -p "$DEVICE_OUT"
 
-health_check(){
-  adb start-server >/dev/null 2>&1
-  if ! adb -s "$DEVICE" get-state >/dev/null 2>&1; then
-    log_warn "Device $DEVICE unreachable, restarting server"
-    adb kill-server >/dev/null 2>&1 || true
-    adb start-server >/dev/null 2>&1
-    adb -s "$DEVICE" get-state >/dev/null 2>&1 || { log_error "Device $DEVICE unhealthy"; exit 1; }
-  fi
-  adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
-}
+LOG_FILE="$DEVICE_OUT/run_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
-adb_s(){ adb -s "$DEVICE" "$@"; }
+echo "Running on device: $DEVICE"
 
-#####################
-# RUN SETUP
-#####################
-init_run(){
-  RUN_ID="$(date +%Y%m%d_%H%M%S)"
-  RUN_DIR="$OUTDIR/$DEVICE/$RUN_ID"
-  mkdir -p "$RUN_DIR/raw" "$RUN_DIR/apks" "$RUN_DIR/reports"
-  ln -sfn "$RUN_DIR" "$OUTDIR/$DEVICE/latest"
-  MASTER_CSV="$RUN_DIR/${DEVICE}.${RUN_ID}.apps.csv"
-  SUMMARY_FILE="$RUN_DIR/${DEVICE}.${RUN_ID}.summary.txt"
-  ROOT_FILE="$RUN_DIR/${DEVICE}.${RUN_ID}.root_status.txt"
-  RAW_PM_LIST="$RUN_DIR/raw/raw_pm_list.txt"
-  PARSER_VERSION="1.0"
-  TOOL_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
-  ADB_VERSION="$(adb version | head -n1 | awk '{print $3}')"
-  CAPTURED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  SOURCE_CMD="adb -s $DEVICE shell pm list packages -f"
-  HEADER="device_serial,run_id,package,apk_path,partition,is_user,is_social,social_method,version_name,version_code,permissions,sha256,hash_source,is_running,detection_notes,source_cmd,parser_version,tool_commit,adb_version,captured_at"
-  write_csv_header "$MASTER_CSV" "$HEADER"
-  log_info "Run ID: $RUN_ID"
-  log_info "Run directory: $RUN_DIR"
-}
+# Generate core datasets
+"$SCRIPT_DIR/steps/generate_apk_list.sh" -d "$DEVICE"
+"$SCRIPT_DIR/steps/generate_apk_metadata.sh" -d "$DEVICE"
+"$SCRIPT_DIR/steps/generate_apk_hashes.sh" -d "$DEVICE"
+"$SCRIPT_DIR/steps/generate_running_apps.sh" -d "$DEVICE"
 
-#####################
-# DISCOVERY
-#####################
-discover_packages(){
-  log_info "Discovering packages"
-  adb_s shell pm list packages -f | tr -d '\r' > "$RAW_PM_LIST"
-  while IFS= read -r line; do
-    [[ -z "$line" ]] && continue
-    entry=${line#package:}
-    apk_path=${entry%%=*}
-    pkg=${entry##*=}
-    partition=$(echo "$apk_path" | cut -d/ -f2)
-    is_user=false; [[ "$partition" == "data" ]] && is_user=true
-    append_csv_row "$MASTER_CSV" "$DEVICE,$RUN_ID,$pkg,$apk_path,$partition,$is_user,false,none,N/A,N/A,,,none,false,pm list,$SOURCE_CMD,$PARSER_VERSION,$TOOL_COMMIT,$ADB_VERSION,$CAPTURED_AT"
-  done < "$RAW_PM_LIST"
-  RAW_COUNT=$(wc -l < "$RAW_PM_LIST")
-  CSV_COUNT=$(( $(wc -l < "$MASTER_CSV") -1 ))
-  [[ $RAW_COUNT -eq $CSV_COUNT ]] || { log_error "Discovery count mismatch"; exit 1; }
-  log_info "apps inventory updated: $CSV_COUNT rows"
-}
+# Social app report
+"$SCRIPT_DIR/find_social_apps.sh" -d "$DEVICE"
 
-#####################
-# SOCIAL TRIAGE
-#####################
-social_triage(){
-  log_info "Running social triage"
-  local tmp="$MASTER_CSV.tmp"; echo "$HEADER" > "$tmp"
-  tail -n +2 "$MASTER_CSV" | while IFS=',' read -r dev run pkg apk_path partition is_user is_social social_method version_name version_code permissions sha256 hash_source is_running detection_notes source_cmd parser_version tool_commit adb_version captured_at; do
-    social=$is_social; method=$social_method; notes=$detection_notes
-    for entry in "${SOCIAL_APPS[@]}"; do
-      canonical=${entry%%:*}
-      if [[ "$pkg" == "$canonical" ]]; then
-        social=true; method=exact; notes="exact:$pkg"; break
-      fi
-    done
-    if [[ "$social" == false ]]; then
-      for kw in "${SOCIAL_KEYWORDS[@]}"; do
-        if [[ "$pkg" == *"$kw"* ]]; then social=true; method=heuristic; notes="keyword:$kw"; break; fi
-      done
-    fi
-    echo "$dev,$run,$pkg,$apk_path,$partition,$is_user,$social,$method,$version_name,$version_code,$permissions,$sha256,$hash_source,$is_running,$notes,$source_cmd,$parser_version,$tool_commit,$adb_version,$captured_at" >> "$tmp"
-  done
-  mv "$tmp" "$MASTER_CSV"
-}
-
-#####################
-# METADATA
-#####################
-extract_metadata(){
-  log_info "Extracting metadata"
-  tail -n +2 "$MASTER_CSV" | cut -d, -f3,4 | while IFS=',' read -r pkg apk_path; do
-    VERSION_NAME=$(adb_s shell dumpsys package "$pkg" | awk -F= '/versionName=/{print $2;exit}' | tr -d '\r')
-    VERSION_CODE=$(adb_s shell dumpsys package "$pkg" | awk -F= '/versionCode=/{gsub(/ .*/,"",$2);print $2;exit}' | tr -d '\r')
-    PERMS=$(adb_s shell dumpsys package "$pkg" | grep -E "permission " | awk '{print $1}' | paste -sd ';' -)
-    update_field "$MASTER_CSV" "$pkg" 9 "${VERSION_NAME:-N/A}"
-    update_field "$MASTER_CSV" "$pkg" 10 "${VERSION_CODE:-N/A}"
-    update_field "$MASTER_CSV" "$pkg" 11 "${PERMS}"
-  done
-  MISSING=$(tail -n +2 "$MASTER_CSV" | awk -F, '$9==""' | wc -l)
-  [[ $MISSING -eq 0 ]] || log_warn "$MISSING packages missing version info"
-}
-
-#####################
-# HASHING
-#####################
-compute_hashes(){
-  log_info "Hashing APKs"
-  tail -n +2 "$MASTER_CSV" | cut -d, -f3,4 | while IFS=',' read -r pkg apk_path; do
-    HASH=$(adb_s shell sha256sum "$apk_path" 2>/dev/null | awk '{print $1}')
-    SRC="device"
-    if [[ -z "$HASH" ]]; then
-      if adb_s pull "$apk_path" "$RUN_DIR/apks/$pkg.apk" >/dev/null 2>&1; then
-        HASH=$(sha256sum "$RUN_DIR/apks/$pkg.apk" | awk '{print $1}')
-        SRC="host"
-      else
-        update_field "$MASTER_CSV" "$pkg" 15 "hash failed (no access)"
-      fi
-    fi
-    [[ -n "$HASH" ]] && update_field "$MASTER_CSV" "$pkg" 12 "$HASH" && update_field "$MASTER_CSV" "$pkg" 13 "$SRC"
-  done
-  HASHED=$(tail -n +2 "$MASTER_CSV" | awk -F, '$12!=""' | wc -l)
-  TOTAL=$(( $(wc -l < "$MASTER_CSV") -1 ))
-  log_info "Hashes computed: $HASHED/$TOTAL"
-}
-
-#####################
-# RUNNING PROCESSES
-#####################
-check_running(){
-  log_info "Checking running processes"
-  tail -n +2 "$MASTER_CSV" | cut -d, -f3 | while read -r pkg; do
-    PID=$(adb_s shell pidof "$pkg" 2>/dev/null | tr -d '\r')
-    [[ -n "$PID" ]] && update_field "$MASTER_CSV" "$pkg" 14 true
-  done
-}
-
-#####################
-# ROOT PROBE
-#####################
-root_probe(){
-  log_info "Probing root capabilities"
-  {
-    echo "adb root:"; adb -s "$DEVICE" root 2>&1 || true
-    echo "su -c id:"; adb -s "$DEVICE" shell su -c id 2>&1 || true
-  } > "$ROOT_FILE"
-}
-
-#####################
-# SUMMARY
-#####################
-write_summary(){
-  local total social_exact social_heuristic running_social hash_ok hash_fail user_pkgs
-  total=$(( $(wc -l < "$MASTER_CSV") -1 ))
-  user_pkgs=$(tail -n +2 "$MASTER_CSV" | awk -F, '$6=="true"' | wc -l)
-  social_exact=$(tail -n +2 "$MASTER_CSV" | awk -F, '$7=="true" && $8=="exact"' | wc -l)
-  social_heuristic=$(tail -n +2 "$MASTER_CSV" | awk -F, '$7=="true" && $8=="heuristic"' | wc -l)
-  running_social=$(tail -n +2 "$MASTER_CSV" | awk -F, '$7=="true" && $14=="true"' | wc -l)
-  hash_ok=$(tail -n +2 "$MASTER_CSV" | awk -F, '$12!=""' | wc -l)
-  hash_fail=$((total-hash_ok))
-  {
-    echo "Artifact naming: <serial>.<run-id>.<artifact>.<ext>"
-    echo "Device: $DEVICE"
-    echo "Run ID: $RUN_ID"
-    echo "Total packages: $total"
-    echo "User packages: $user_pkgs"
-    echo "Social apps (exact): $social_exact"
-    echo "Social apps (heuristic): $social_heuristic"
-    echo "Running social apps: $running_social"
-    echo "Hashes: $hash_ok success / $hash_fail failure"
-    printf "\nSocial app summary:\n"
-    tail -n +2 "$MASTER_CSV" | awk -F, '$7=="true"{printf "%-40s %-9s %s\n", $3, $8, ($12!=""?"hash" : "nohash");}'
-    printf "\nArtifacts live under: %s\n" "$RUN_DIR"
-    printf "\nNext actions:\n  # inspect a package\n  adb -s %s shell dumpsys package <package>\n" "$DEVICE"
-  } > "$SUMMARY_FILE"
-}
-
-#####################
-# DERIVED VIEWS (OPTIONAL)
-#####################
-generate_derived_views(){
-  [ "$GENERATE_DERIVED" = true ] || return 0
-  local social="$RUN_DIR/${DEVICE}.${RUN_ID}.social_apps_derived.csv"
-  local running="$RUN_DIR/${DEVICE}.${RUN_ID}.running_apps_derived.csv"
-  { echo "$HEADER"; tail -n +2 "$MASTER_CSV" | awk -F, '$7=="true"{print}' ; } > "$social"
-  { echo "$HEADER"; tail -n +2 "$MASTER_CSV" | awk -F, '$14=="true"{print}' ; } > "$running"
-}
-
-#####################
-# CSV FIELD UPDATER
-#####################
-update_field(){
-  local file="$1" pkg="$2" col="$3" val="$4"
-  awk -F, -v pkg="$pkg" -v col="$col" -v val="$val" 'BEGIN{OFS=","} NR==1{print;next} $3==pkg{$col=val} {print}' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
-}
-
-
-#####################
-# MAIN FLOW
-#####################
-check_adb
-DEVICE=$(select_device)
-log_info "Selected device: $DEVICE"
-health_check
-[[ $NON_INTERACTIVE -eq 1 ]] && log_info "Non-interactive mode"
-init_run
-discover_packages
-social_triage
-extract_metadata
-compute_hashes
-check_running
-root_probe
-write_summary
-generate_derived_views
-
-log_info "Run complete"
-log_info "Master inventory → $MASTER_CSV"
-log_info "Summary → $SUMMARY_FILE"
+# Manifest and summary
+"$SCRIPT_DIR/steps/generate_manifest.sh" -d "$DEVICE" -l "$LOG_FILE"

--- a/steps/generate_apk_hashes.sh
+++ b/steps/generate_apk_hashes.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Generate apk_hashes.csv for a device
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+APK_LIST="$DEVICE_OUT/apk_list.csv"
+HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
+
+write_csv_header "$HASH_FILE" "Package,SHA256,HashSource"
+
+tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
+    hash=$(adb -s "$DEVICE" shell sha256sum "$apk_path" 2>/dev/null | awk '{print $1}')
+    src=device
+    if [[ -z "$hash" ]]; then
+        tmp=$(mktemp)
+        if adb -s "$DEVICE" pull "$apk_path" "$tmp" >/dev/null 2>&1; then
+            hash=$(sha256sum "$tmp" | awk '{print $1}')
+            src=host
+        fi
+        rm -f "$tmp"
+    fi
+    append_csv_row "$HASH_FILE" "$pkg,${hash},$src"
+done
+
+validate_csv "$HASH_FILE" "Package,SHA256,HashSource"

--- a/steps/generate_apk_list.sh
+++ b/steps/generate_apk_list.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Generate apk_list.csv for a device
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+mkdir -p "$DEVICE_OUT"
+
+APK_LIST="$DEVICE_OUT/apk_list.csv"
+write_csv_header "$APK_LIST" "Package,APK_Path"
+SOURCE_CMD="adb -s $DEVICE shell pm list packages -f"
+$SOURCE_CMD | tr -d '\r' | sed 's/^package://g' | awk -F= '{print $2 "," $1}' | sort -f >> "$APK_LIST"
+validate_csv "$APK_LIST" "Package,APK_Path"

--- a/steps/generate_apk_metadata.sh
+++ b/steps/generate_apk_metadata.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Generate apk_metadata.csv for a device
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+APK_LIST="$DEVICE_OUT/apk_list.csv"
+META_FILE="$DEVICE_OUT/apk_metadata.csv"
+
+write_csv_header "$META_FILE" "Package,Version,Permissions"
+
+tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
+    version=$(adb -s "$DEVICE" shell dumpsys package "$pkg" | awk -F= '/versionName=/{print $2;exit}' | tr -d '\r')
+    perms=$(adb -s "$DEVICE" shell dumpsys package "$pkg" | awk '/permission/ {print $1}' | paste -sd ';' -)
+    append_csv_row "$META_FILE" "$pkg,${version:-N/A},\"${perms}\""
+done
+
+validate_csv "$META_FILE" "Package,Version,Permissions"

--- a/steps/generate_manifest.sh
+++ b/steps/generate_manifest.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Generate manifest.json and run summary for a device
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+LOG_FILE=""
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -l|--log)
+            LOG_FILE="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+APK_LIST="$DEVICE_OUT/apk_list.csv"
+META_FILE="$DEVICE_OUT/apk_metadata.csv"
+HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
+RUNNING_FILE="$DEVICE_OUT/running_apps.csv"
+SOCIAL_FILE="$DEVICE_OUT/social_apps_found.csv"
+
+TOTAL_PKGS=$(( $(wc -l < "$APK_LIST") -1 ))
+if [[ -f "$SOCIAL_FILE" ]]; then
+    Y_COUNT=$(awk -F, 'NR>1 && $4=="Y" && $3=="data"' "$SOCIAL_FILE" | wc -l)
+    Q_COUNT=$(awk -F, 'NR>1 && $4=="?" && $3=="data"' "$SOCIAL_FILE" | wc -l)
+    P_COUNT=$(awk -F, 'NR>1 && $4=="P"' "$SOCIAL_FILE" | wc -l)
+else
+    Y_COUNT=0; Q_COUNT=0; P_COUNT=0
+fi
+
+cat > "$DEVICE_OUT/manifest.json" <<MANIFEST
+{
+  "packages_total": $TOTAL_PKGS,
+  "social_exact_data": $Y_COUNT,
+  "social_heuristic_data": $Q_COUNT,
+  "social_preload": $P_COUNT,
+  "files": {
+    "apk_list": "apk_list.csv",
+    "apk_metadata": "apk_metadata.csv",
+    "apk_hashes": "apk_hashes.csv",
+    "running_apps": "running_apps.csv",
+    "social_apps": "$( [[ -f "$SOCIAL_FILE" ]] && echo social_apps_found.csv || echo "" )",
+    "log": "$(basename "$LOG_FILE")"
+  }
+}
+MANIFEST
+
+echo "Run Summary"
+echo "-----------"
+printf "%-25s %s\n" "apk_list.csv" "$(( $(wc -l < "$APK_LIST") -1 )) rows"
+printf "%-25s %s\n" "apk_metadata.csv" "$(( $(wc -l < "$META_FILE") -1 )) rows"
+printf "%-25s %s\n" "apk_hashes.csv" "$(( $(wc -l < "$HASH_FILE") -1 )) rows"
+printf "%-25s %s\n" "running_apps.csv" "$(( $(wc -l < "$RUNNING_FILE") -1 )) rows"
+if [[ -f "$SOCIAL_FILE" ]]; then
+    printf "%-25s %s\n" "social_apps_found.csv" "$(( $(wc -l < "$SOCIAL_FILE") -1 )) rows"
+    echo "User-installed social apps (data+Y): $Y_COUNT"
+    echo "Preload social components (P): $P_COUNT"
+fi
+echo "Log: $(basename "$LOG_FILE")"

--- a/steps/generate_running_apps.sh
+++ b/steps/generate_running_apps.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Generate running_apps.csv for a device
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/output_utils.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+    case "$1" in
+        -d|--device)
+            DEVICE_ARG="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
+adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+
+DEVICE_OUT="$OUTDIR/$DEVICE"
+APK_LIST="$DEVICE_OUT/apk_list.csv"
+RUNNING_FILE="$DEVICE_OUT/running_apps.csv"
+
+write_csv_header "$RUNNING_FILE" "Package,PID"
+
+tail -n +2 "$APK_LIST" | while IFS=, read -r pkg _; do
+    pid=$(adb -s "$DEVICE" shell pidof "$pkg" 2>/dev/null | tr -d '\r')
+    if [[ -n "$pid" ]]; then
+        append_csv_row "$RUNNING_FILE" "$pkg,$pid"
+    fi
+done
+
+validate_csv "$RUNNING_FILE" "Package,PID"

--- a/utils/validate_csv.sh
+++ b/utils/validate_csv.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Utility: validate_csv.sh
+# Checks CSV header and Package-sorted order
+
+validate_csv() {
+    local file="$1"
+    local expected="$2"
+    if [[ ! -f "$file" ]]; then
+        echo "validate_csv: missing $file" >&2
+        return 1
+    fi
+    local header
+    header=$(head -n1 "$file")
+    if [[ "$header" != "$expected" ]]; then
+        echo "validate_csv: header mismatch in $file" >&2
+        return 1
+    fi
+    awk -F, 'NR==2{prev=tolower($1);next} NR>2{cur=tolower($1); if(cur<prev){exit 1} prev=cur}' "$file" || {
+        echo "validate_csv: Package column not sorted in $file" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## Summary
- modularize run pipeline into discrete step scripts for APK listing, metadata, hashing, running processes, and manifest generation
- delegate orchestration to a streamlined run script and let social detection validate its own CSV

## Testing
- `bash -n config.sh`
- `bash -n run.sh`
- `bash -n find_social_apps.sh`
- `bash -n steps/generate_apk_list.sh`
- `bash -n steps/generate_apk_metadata.sh`
- `bash -n steps/generate_apk_hashes.sh`
- `bash -n steps/generate_running_apps.sh`
- `bash -n steps/generate_manifest.sh`
- `bash -n utils/validate_csv.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7e85b24e483278fe86f050a6f5363