### PR TITLE
Normalize APK list column order for social app scan

### DIFF
--- a/parse_apks.sh
+++ b/parse_apks.sh
@@ -14,7 +14,7 @@ TMPFILE=$(mktemp)
 
 echo "Package,APK_Path,Source,Type,Category,Flags" > "$TMPFILE"
 
-grep -v '^$' "$INPUT" | while IFS=, read -r APK_PATH PKG_NAME; do
+tail -n +2 "$INPUT" | while IFS=, read -r PKG_NAME APK_PATH; do
     # Skip broken rows
     if [[ -z "$APK_PATH" || -z "$PKG_NAME" ]]; then
         continue


### PR DESCRIPTION
## Summary
- Ensure APK list CSV writes package before path for consistent parsing
- Adjust downstream loops to match new column order
- Update parsing script to read package-first CSVs

## Testing
- `bash -n apk_actions.sh`
- `shellcheck apk_actions.sh`
- `bash -n parse_apks.sh`
- `shellcheck parse_apks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a7f7376c4483279afa1cd442ac7e5f