### PR TITLE
Source logging utilities in output utils

### DIFF
--- a/utils/output_utils.sh
+++ b/utils/output_utils.sh
@@ -2,6 +2,10 @@
 # Library: output_utils.sh
 # Provides helper functions for CSV output and file presence checks
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils/logging_utils.sh
+source "$SCRIPT_DIR/logging_utils.sh"
+
 # Write CSV header to a file, overwriting existing content
 write_csv_header() {
     local file="$1"
@@ -20,7 +24,11 @@ append_csv_row() {
 require_file() {
     local file="$1"
     if [ ! -f "$file" ] || [ ! -s "$file" ]; then
-        log_error "Required file $file missing or empty."
+        if declare -f log_error >/dev/null 2>&1; then
+            log_error "Required file $file missing or empty."
+        else
+            echo "Required file $file missing or empty." >&2
+        fi
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- source `logging_utils.sh` in `output_utils.sh`
- ensure `require_file` falls back to stderr if `log_error` absent
- fix ShellCheck directive path and run shellcheck with external sources

## Testing
- `bash -n utils/output_utils.sh`
- `shellcheck -x utils/output_utils.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8a50c238c8327b66d48a2c4c93ce0