### PR TITLE
Refactor run orchestration for timestamped outputs

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-# Orchestrate device data collection using step scripts
+# Orchestrated full device scan
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/config.sh"
 source "$SCRIPT_DIR/list_devices.sh"
 source "$SCRIPT_DIR/utils/display/base.sh"
-source "$SCRIPT_DIR/utils/display/banners.sh"
-source "$SCRIPT_DIR/utils/display/menu.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
 
 DEVICE_ARG=""
 while [[ ${1-} ]]; do
@@ -23,89 +22,45 @@ while [[ ${1-} ]]; do
     esac
 done
 
-setup_logging() {
-    DEVICE_OUT="$OUTDIR/$DEVICE"
-    mkdir -p "$DEVICE_OUT"
-    LOG_FILE="$DEVICE_OUT/run_$(date +%Y%m%d_%H%M%S).log"
-    exec > >(tee -a "$LOG_FILE") 2>&1
-    status_info "Logs: $LOG_FILE"
-}
-
-run_apk_list()      { status_info "Generating APK list"; "$SCRIPT_DIR/steps/generate_apk_list.sh" -d "$DEVICE"; }
-run_social_scan()   { status_info "Finding social apps"; "$SCRIPT_DIR/find_social_apps.sh" -d "$DEVICE"; }
-run_motorola_scan() { status_info "Listing Motorola apps"; "$SCRIPT_DIR/find_motorola_apps.sh" -d "$DEVICE"; }
-run_apk_hashes()    { status_info "Computing APK hashes"; "$SCRIPT_DIR/steps/generate_apk_hashes.sh" -d "$DEVICE"; }
-run_apk_metadata()  { status_info "Extracting APK metadata"; "$SCRIPT_DIR/steps/generate_apk_metadata.sh" -d "$DEVICE"; }
-run_running_apps()  { status_info "Listing running processes"; "$SCRIPT_DIR/steps/generate_running_apps.sh" -d "$DEVICE"; }
-run_pull_tiktok()   { status_info "Pulling TikTok APK"; "$SCRIPT_DIR/pull_tiktok_apk.sh" -d "$DEVICE" -o "$DEVICE_OUT"; }
-run_screenshot()    { status_info "Capturing screenshot"; "$SCRIPT_DIR/capture_screenshot.sh" -d "$DEVICE" -o "$DEVICE_OUT"; }
-run_shell()         { "$SCRIPT_DIR/device_shell.sh" -d "$DEVICE"; }
-view_social_report() {
-    local file="$OUTDIR/$DEVICE/social_apps_found.csv"
-    if [[ -f "$file" ]]; then
-        status_info "Social app report:" && column -t -s, "$file"
-    else
-        status_warn "No social app report found. Run the scan first."
-    fi
-}
-view_motorola_report() {
-    local file="$OUTDIR/$DEVICE/motorola_apps.csv"
-    if [[ -f "$file" ]]; then
-        status_info "Motorola app report:" && column -t -s, "$file"
-    else
-        status_warn "No Motorola report found. Run the scan first."
-    fi
-}
-run_full_scan() {
-    run_apk_list
-    run_apk_metadata
-    run_apk_hashes
-    run_running_apps
-    run_social_scan
-    run_motorola_scan
-    "$SCRIPT_DIR/steps/generate_manifest.sh" -d "$DEVICE" -l "$LOG_FILE"
-    status_ok "Full scan complete. Reports saved to $DEVICE_OUT"
-}
-
-switch_device() {
-    status_info "Switching device"
-    DEVICE=$(list_devices "") || return 1
-    adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
-    setup_logging
-    status_ok "Now using device: $DEVICE"
-}
-
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
-print_banner
-status_info "Running on device: $DEVICE"
-setup_logging
 
-while true; do
-    print_menu
-    printf "${BOLD}Select an option:${RESET} "
-    read -r choice
-    case "$choice" in
-        1) run_apk_list ;;
-        2) run_social_scan ;;
-        3) run_motorola_scan ;;
-        4) run_apk_hashes ;;
-        5) run_apk_metadata ;;
-        6) run_running_apps ;;
-        7) run_pull_tiktok ;;
-        8) run_screenshot ;;
-        9) run_shell ;;
-        10) run_full_scan ;;
-        11) switch_device ;;
-        12) view_social_report ;;
-        13) view_motorola_report ;;
-        0)
-            status_info "Exiting"
-            break
-            ;;
-        *)
-            status_warn "Invalid option"
-            ;;
-    esac
-done
+RUN_TS=$(date +%Y%m%d_%H%M%S)
+DEVICE_DIR="$OUTDIR/$DEVICE"
+DEVICE_OUT="$DEVICE_DIR/$RUN_TS"
+mkdir -p "$DEVICE_OUT"/{apks,raw,reports}
+ln -sfn "$RUN_TS" "$DEVICE_DIR/latest"
+
+LOG_FILE="$DEVICE_OUT/run.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+status_info "Device: $DEVICE"
+status_info "Output: $DEVICE_OUT"
+
+run_step() {
+    local script="$1"
+    local csv="$2"
+    local header="$3"
+    shift 3
+    status_info "Running $(basename "$script")"
+    "$script" --device "$DEVICE" --out "$DEVICE_OUT" "$@"
+    if [[ -n "$csv" && -n "$header" ]]; then
+        validate_csv "$csv" "$header"
+    fi
+}
+
+run_step "$SCRIPT_DIR/steps/generate_apk_list.sh" \
+    "$DEVICE_OUT/reports/apk_list.csv" "Package,APK_Path"
+run_step "$SCRIPT_DIR/steps/generate_apk_metadata.sh" \
+    "$DEVICE_OUT/reports/apk_metadata.csv" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"
+run_step "$SCRIPT_DIR/steps/generate_apk_hashes.sh" \
+    "$DEVICE_OUT/reports/apk_hashes.csv" "Package,SHA256,HashSource"
+run_step "$SCRIPT_DIR/steps/generate_running_apps.sh" \
+    "$DEVICE_OUT/reports/running_apps.csv" "Package,PID"
+run_step "$SCRIPT_DIR/find_social_apps.sh" \
+    "$DEVICE_OUT/reports/social_apps_found.csv" "Package,APK_Path,InstallType,Detected,Family,Confidence,SHA256,SourceCommand"
+run_step "$SCRIPT_DIR/find_motorola_apps.sh" \
+    "$DEVICE_OUT/reports/motorola_apps.csv" "Package,APK_Path"
+run_step "$SCRIPT_DIR/steps/generate_manifest.sh" "" "" --log "$LOG_FILE"
+status_ok "Full scan complete. Reports saved to $DEVICE_OUT"
 

--- a/steps/generate_apk_hashes.sh
+++ b/steps/generate_apk_hashes.sh
@@ -11,10 +11,15 @@ source "$SCRIPT_DIR/utils/display/base.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
 
 DEVICE_ARG=""
+OUT_ARG=""
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
             DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -26,9 +31,12 @@ done
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-DEVICE_OUT="$OUTDIR/$DEVICE"
-APK_LIST="$DEVICE_OUT/apk_list.csv"
-HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
+
+APK_LIST="$REPORT_DIR/apk_list.csv"
+HASH_FILE="$REPORT_DIR/apk_hashes.csv"
 
 status_info "Hashing APKs for $DEVICE"
 write_csv_header "$HASH_FILE" "Package,SHA256,HashSource"

--- a/steps/generate_apk_list.sh
+++ b/steps/generate_apk_list.sh
@@ -11,10 +11,15 @@ source "$SCRIPT_DIR/utils/display/base.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
 
 DEVICE_ARG=""
+OUT_ARG=""
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
             DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -26,10 +31,11 @@ done
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-DEVICE_OUT="$OUTDIR/$DEVICE"
-mkdir -p "$DEVICE_OUT"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
 
-APK_LIST="$DEVICE_OUT/apk_list.csv"
+APK_LIST="$REPORT_DIR/apk_list.csv"
 status_info "Pulling package list from $DEVICE"
 write_csv_header "$APK_LIST" "Package,APK_Path"
 SOURCE_CMD="adb -s $DEVICE shell pm list packages -f"

--- a/steps/generate_apk_metadata.sh
+++ b/steps/generate_apk_metadata.sh
@@ -11,10 +11,15 @@ source "$SCRIPT_DIR/utils/display/base.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
 
 DEVICE_ARG=""
+OUT_ARG=""
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
             DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -26,9 +31,12 @@ done
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-DEVICE_OUT="$OUTDIR/$DEVICE"
-APK_LIST="$DEVICE_OUT/apk_list.csv"
-META_FILE="$DEVICE_OUT/apk_metadata.csv"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
+
+APK_LIST="$REPORT_DIR/apk_list.csv"
+META_FILE="$REPORT_DIR/apk_metadata.csv"
 
 status_info "Extracting metadata from packages on $DEVICE"
 write_csv_header "$META_FILE" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"

--- a/steps/generate_manifest.sh
+++ b/steps/generate_manifest.sh
@@ -12,6 +12,7 @@ source "$SCRIPT_DIR/utils/display/status.sh"
 
 LOG_FILE=""
 DEVICE_ARG=""
+OUT_ARG=""
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
@@ -20,6 +21,10 @@ while [[ ${1-} ]]; do
             ;;
         -l|--log)
             LOG_FILE="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -31,12 +36,14 @@ done
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-DEVICE_OUT="$OUTDIR/$DEVICE"
-APK_LIST="$DEVICE_OUT/apk_list.csv"
-META_FILE="$DEVICE_OUT/apk_metadata.csv"
-HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
-RUNNING_FILE="$DEVICE_OUT/running_apps.csv"
-SOCIAL_FILE="$DEVICE_OUT/social_apps_found.csv"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
+APK_LIST="$REPORT_DIR/apk_list.csv"
+META_FILE="$REPORT_DIR/apk_metadata.csv"
+HASH_FILE="$REPORT_DIR/apk_hashes.csv"
+RUNNING_FILE="$REPORT_DIR/running_apps.csv"
+SOCIAL_FILE="$REPORT_DIR/social_apps_found.csv"
 
 TOTAL_PKGS=$(( $(wc -l < "$APK_LIST") -1 ))
 if [[ -f "$SOCIAL_FILE" ]]; then

--- a/steps/generate_running_apps.sh
+++ b/steps/generate_running_apps.sh
@@ -11,10 +11,15 @@ source "$SCRIPT_DIR/utils/display/base.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
 
 DEVICE_ARG=""
+OUT_ARG=""
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
             DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -26,9 +31,12 @@ done
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-DEVICE_OUT="$OUTDIR/$DEVICE"
-APK_LIST="$DEVICE_OUT/apk_list.csv"
-RUNNING_FILE="$DEVICE_OUT/running_apps.csv"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
+
+APK_LIST="$REPORT_DIR/apk_list.csv"
+RUNNING_FILE="$REPORT_DIR/running_apps.csv"
 
 status_info "Checking running processes on $DEVICE"
 write_csv_header "$RUNNING_FILE" "Package,PID"


### PR DESCRIPTION
## Summary
- Orchestrate full device scan sequentially in `run.sh` with timestamped output directories and latest symlink
- Add output path option to scanning scripts and always validate generated CSVs
- Ensure social and Motorola scans generate consistent reports even with no matches
- Integrate manifest generation into the unified step runner and clean up unused variables

## Testing
- `shellcheck run.sh steps/*.sh find_social_apps.sh find_motorola_apps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8a5030e24832780a83ee966dd2f79