### PR TITLE
Fix subshell counts in APK list processing scripts

### DIFF
--- a/apk_actions.sh
+++ b/apk_actions.sh
@@ -62,16 +62,19 @@ hash_apks() {
     log_info "Computing SHA-256 hashes..."
     write_csv_header "$MANIFEST" "Package,APK_Path,SHA256"
 
-    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r PKG_NAME APK_PATH; do
+    count=0
+    while IFS=, read -r PKG_NAME APK_PATH; do
         HASH=$(adb -s "$DEVICE" shell sha256sum "$APK_PATH" 2>/dev/null | awk '{print $1}')
         if [ -n "$HASH" ]; then
             append_csv_row "$MANIFEST" "$PKG_NAME,$APK_PATH,$HASH"
+            ((count++))
         else
             log_warn "Could not hash $PKG_NAME ($APK_PATH)"
         fi
-    done
+    done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
-    log_info "Hash manifest saved → $MANIFEST"
+    validate_csv "$MANIFEST" "Package,APK_Path,SHA256"
+    log_info "Hashed $count APKs → $MANIFEST"
 }
 
 apk_metadata() {
@@ -83,13 +86,16 @@ apk_metadata() {
     log_info "Extracting version & permissions..."
     write_csv_header "$METADATAFILE" "Package,Version,Permissions"
 
-    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r PKG_NAME APK_PATH; do
+    count=0
+    while IFS=, read -r PKG_NAME APK_PATH; do
         VERSION=$(adb -s "$DEVICE" shell dumpsys package "$PKG_NAME" | grep -m1 versionName | awk -F= '{print $2}')
         PERMS=$(adb -s "$DEVICE" shell dumpsys package "$PKG_NAME" | grep -E "permission " | awk '{print $1}' | tr '\n' ';')
         append_csv_row "$METADATAFILE" "$PKG_NAME,${VERSION:-N/A},\"$PERMS\""
-    done
+        ((count++))
+    done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
-    log_info "Metadata saved → $METADATAFILE"
+    validate_csv "$METADATAFILE" "Package,Version,Permissions"
+    log_info "Metadata saved for $count packages → $METADATAFILE"
 }
 
 running_processes() {
@@ -101,10 +107,15 @@ running_processes() {
     log_info "Checking running processes..."
     write_csv_header "$RUNNINGFILE" "Package,PID"
 
-    tail -n +2 "$DEVICE_OUT/apk_list.csv" | while IFS=, read -r PKG_NAME APK_PATH; do
+    count=0
+    while IFS=, read -r PKG_NAME APK_PATH; do
         PID=$(adb -s "$DEVICE" shell pidof "$PKG_NAME" 2>/dev/null)
-        [ -n "$PID" ] && append_csv_row "$RUNNINGFILE" "$PKG_NAME,$PID"
-    done
+        if [ -n "$PID" ]; then
+            append_csv_row "$RUNNINGFILE" "$PKG_NAME,$PID"
+            ((count++))
+        fi
+    done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
-    log_info "Running apps list saved → $RUNNINGFILE"
+    validate_csv "$RUNNINGFILE" "Package,PID"
+    log_info "Logged $count running apps → $RUNNINGFILE"
 }

--- a/steps/generate_apk_hashes.sh
+++ b/steps/generate_apk_hashes.sh
@@ -33,7 +33,7 @@ HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
 status_info "Hashing APKs for $DEVICE"
 write_csv_header "$HASH_FILE" "Package,SHA256,HashSource"
 count=0
-tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
+while IFS=, read -r pkg apk_path; do
     hash=$(adb -s "$DEVICE" shell sha256sum "$apk_path" 2>/dev/null | awk '{print $1}')
     src=device
     if [[ -z "$hash" ]]; then
@@ -47,7 +47,7 @@ tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
     append_csv_row "$HASH_FILE" "$pkg,${hash},$src"
     status_info "Hashed $pkg"
     ((count++))
-done
+done < <(tail -n +2 "$APK_LIST")
 
 validate_csv "$HASH_FILE" "Package,SHA256,HashSource"
 status_ok "Wrote $count hashes to $HASH_FILE"

--- a/steps/generate_apk_metadata.sh
+++ b/steps/generate_apk_metadata.sh
@@ -33,7 +33,7 @@ META_FILE="$DEVICE_OUT/apk_metadata.csv"
 status_info "Extracting metadata from packages on $DEVICE"
 write_csv_header "$META_FILE" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"
 count=0
-tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
+while IFS=, read -r pkg apk_path; do
     dump=$(adb -s "$DEVICE" shell dumpsys package "$pkg")
     version=$(awk -F= '/versionName=/{print $2;exit}' <<<"$dump" | tr -d '\r')
     min_sdk=$(awk -F= '/minSdk=/{print $2;exit}' <<<"$dump" | tr -d '\r')
@@ -43,7 +43,7 @@ tail -n +2 "$APK_LIST" | while IFS=, read -r pkg apk_path; do
     append_csv_row "$META_FILE" "$pkg,${version:-N/A},${min_sdk:-N/A},${target_sdk:-N/A},${size:-N/A},\"${perms}\""
     status_info "Metadata for $pkg captured"
     ((count++))
-done
+done < <(tail -n +2 "$APK_LIST")
 
 validate_csv "$META_FILE" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"
 status_ok "Wrote metadata for $count packages to $META_FILE"

--- a/steps/generate_running_apps.sh
+++ b/steps/generate_running_apps.sh
@@ -33,14 +33,14 @@ RUNNING_FILE="$DEVICE_OUT/running_apps.csv"
 status_info "Checking running processes on $DEVICE"
 write_csv_header "$RUNNING_FILE" "Package,PID"
 count=0
-tail -n +2 "$APK_LIST" | while IFS=, read -r pkg _; do
+while IFS=, read -r pkg _; do
     pid=$(adb -s "$DEVICE" shell pidof "$pkg" 2>/dev/null | tr -d '\r')
     if [[ -n "$pid" ]]; then
         append_csv_row "$RUNNING_FILE" "$pkg,$pid"
         status_info "$pkg is running (PID $pid)"
         ((count++))
     fi
-done
+done < <(tail -n +2 "$APK_LIST")
 
 validate_csv "$RUNNING_FILE" "Package,PID"
 status_ok "Logged $count running packages to $RUNNING_FILE"


### PR DESCRIPTION
## Summary
- switch APK processing loops to process substitution so the surrounding shell's `count` variable increments
- keep final CSV validation using the corrected counts
- ensure APK action helpers track counts and validate outputs

## Testing
- `bash -n apk_actions.sh && echo "apk_actions.sh syntax ok"`
- `shellcheck apk_actions.sh`
- `bash -n steps/generate_apk_hashes.sh && echo "generate_apk_hashes.sh syntax ok"`
- `bash -n steps/generate_running_apps.sh && echo "generate_running_apps.sh syntax ok"`
- `bash -n steps/generate_apk_metadata.sh && echo "generate_apk_metadata.sh syntax ok"`
- `shellcheck steps/generate_apk_hashes.sh steps/generate_running_apps.sh steps/generate_apk_metadata.sh` *(SC1091 informational warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a507c8288327a0ab9ef56a1cf694