### PR TITLE
Integrate menu with run.sh and add environment checks

### DIFF
--- a/main_menu.sh
+++ b/main_menu.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# main_menu.sh
+# Interactive menu for running Android tool steps
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/list_devices.sh"
+source "$SCRIPT_DIR/utils/display/base.sh"
+source "$SCRIPT_DIR/utils/display/status.sh"
+source "$SCRIPT_DIR/utils/display/menu.sh"
+source "$SCRIPT_DIR/utils/validate_csv.sh"
+
+DEVICE_ARG=""
+while [[ ${1-} ]]; do
+  case "$1" in
+    -d|--device)
+      DEVICE_ARG="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+check_prereqs() {
+  for cmd in adb sha256sum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      status_error "Missing required command: $cmd"
+      exit 1
+    fi
+  done
+}
+
+check_prereqs
+
+DEVICE="$(list_devices "$DEVICE_ARG")" || exit 1
+OUT_DIR="$OUTDIR/$DEVICE/latest"
+mkdir -p "$OUT_DIR"/{apks,raw,reports}
+
+run_step() {
+  local script="$1"
+  local csv="$2"
+  local header="$3"
+  shift 3
+  status_info "Running $(basename "$script")"
+  "$SCRIPT_DIR/$script" --device "$DEVICE" --out "$OUT_DIR" "$@"
+  if [[ -n "$csv" && -n "$header" ]]; then
+    validate_csv "$csv" "$header"
+  fi
+}
+
+while true; do
+  clear 2>/dev/null || true
+  print_menu "$DEVICE"
+  printf "%b" "${CYAN}[?]${RESET} ${BOLD}Select an option:${RESET} "
+  read -r choice
+
+  case "$choice" in
+    0)
+      exit 0
+      ;;
+    1)
+      run_step steps/generate_apk_list.sh "$OUT_DIR/reports/apk_list.csv" "Package,APK_Path"
+      ;;
+    2)
+      run_step find_social_apps.sh "$OUT_DIR/reports/social_apps_found.csv" "Package,APK_Path,InstallType,Detected,Family,Confidence,SHA256,SourceCommand"
+      ;;
+    3)
+      run_step find_motorola_apps.sh "$OUT_DIR/reports/motorola_apps.csv" "Package,APK_Path"
+      ;;
+    4)
+      run_step steps/generate_apk_hashes.sh "$OUT_DIR/reports/apk_hashes.csv" "Package,APK_Path,SHA256"
+      ;;
+    5)
+      run_step steps/generate_apk_metadata.sh "$OUT_DIR/reports/apk_metadata.csv" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"
+      ;;
+    6)
+      run_step steps/generate_running_apps.sh "$OUT_DIR/reports/running_apps.csv" "Package,PID"
+      ;;
+    7)
+      "$SCRIPT_DIR/pull_tiktok_apk.sh" -d "$DEVICE"
+      ;;
+    8)
+      "$SCRIPT_DIR/capture_screenshot.sh" -d "$DEVICE"
+      ;;
+    9)
+      "$SCRIPT_DIR/device_shell.sh" -d "$DEVICE"
+      ;;
+    10)
+      "$SCRIPT_DIR/run.sh" --device "$DEVICE"
+      ;;
+    11)
+      DEVICE="$(list_devices "")" || continue
+      OUT_DIR="$OUTDIR/$DEVICE/latest"
+      mkdir -p "$OUT_DIR"/{apks,raw,reports}
+      ;;
+    12)
+      if [[ -f "$OUT_DIR/reports/social_apps_found.csv" ]]; then
+        ${PAGER:-less} "$OUT_DIR/reports/social_apps_found.csv"
+      else
+        status_warn "Social report not found"
+      fi
+      ;;
+    13)
+      if [[ -f "$OUT_DIR/reports/motorola_apps.csv" ]]; then
+        ${PAGER:-less} "$OUT_DIR/reports/motorola_apps.csv"
+      else
+        status_warn "Motorola report not found"
+      fi
+      ;;
+    *)
+      status_error "Invalid option"
+      ;;
+  esac
+
+  printf "%b" "\n${GRAY}Press Enter to continue...${RESET}"
+  read -r
+
+done

--- a/steps/generate_apk_hashes.sh
+++ b/steps/generate_apk_hashes.sh
@@ -1,21 +1,37 @@
 #!/bin/bash
-# run.sh
-# Orchestrated full device scan
+# Script: steps/generate_apk_hashes.sh
+# Purpose: Generate apk_hashes.csv for a device.
+# Usage: generate_apk_hashes.sh --device <id> --out <dir>
+# Outputs: <out_dir>/reports/apk_hashes.csv
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/config.sh"
-source "$SCRIPT_DIR/list_devices.sh"
-source "$SCRIPT_DIR/utils/display/base.sh"
-source "$SCRIPT_DIR/utils/display/status.sh"
-source "$SCRIPT_DIR/utils/validate_csv.sh"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/config.sh"
+source "$ROOT_DIR/list_devices.sh"
+source "$ROOT_DIR/utils/output_utils.sh"
+source "$ROOT_DIR/utils/validate_csv.sh"
+source "$ROOT_DIR/utils/display/base.sh"
+source "$ROOT_DIR/utils/display/status.sh"
 
 DEVICE_ARG=""
+OUT_ARG=""
+
+for cmd in adb sha256sum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        status_error "Missing required command: $cmd"
+        exit 1
+    fi
+done
+
 while [[ ${1-} ]]; do
     case "$1" in
         -d|--device)
             DEVICE_ARG="$2"
+            shift 2
+            ;;
+        -o|--out)
+            OUT_ARG="$2"
             shift 2
             ;;
         *)
@@ -25,62 +41,35 @@ while [[ ${1-} ]]; do
 done
 
 if [[ -z "$DEVICE_ARG" ]]; then
-    echo "Error: device argument (-d) required" >&2
+    status_error "Device argument required (--device)"
     exit 1
 fi
 
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-# Timestamped run directory
-RUN_TS=$(date +%Y%m%d_%H%M%S)
-DEVICE_DIR="$OUTDIR/$DEVICE"
-DEVICE_OUT="$DEVICE_DIR/$RUN_TS"
-mkdir -p "$DEVICE_OUT"/{apks,raw,reports}
-ln -sfn "$RUN_TS" "$DEVICE_DIR/latest"
+DEVICE_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$DEVICE_OUT/reports"
+mkdir -p "$REPORT_DIR"
 
-LOG_FILE="$DEVICE_OUT/reports/run.log"
-SUMMARY_FILE="$DEVICE_OUT/reports/run_summary.txt"
+APK_LIST="$REPORT_DIR/apk_list.csv"
+HASH_FILE="$REPORT_DIR/apk_hashes.csv"
 
-# Log everything to file and stdout
-exec > >(tee -a "$LOG_FILE") 2>&1
+if [[ ! -f "$APK_LIST" ]]; then
+    status_error "Missing APK list at $APK_LIST"
+    exit 1
+fi
 
-status_info "Device: $DEVICE"
-status_info "Output: $DEVICE_OUT"
-status_info "Logs: $LOG_FILE"
-status_info "Summary: $SUMMARY_FILE"
+status_info "Computing SHA-256 hashes for packages on $DEVICE"
+write_csv_header "$HASH_FILE" "Package,APK_Path,SHA256"
 
-run_step() {
-    local script="$1"
-    local csv="$2"
-    local header="$3"
-    shift 3
-    status_info "Running $(basename "$script")"
-    "$script" --device "$DEVICE" --out "$DEVICE_OUT" "$@"
-    if [[ -n "$csv" && -n "$header" ]]; then
-        validate_csv "$csv" "$header"
-    fi
-}
+count=0
+while IFS=, read -r pkg apk_path; do
+    [[ "$pkg" == "Package" ]] && continue
+    hash=$(adb -s "$DEVICE" shell "sha256sum \"$apk_path\"" 2>/dev/null | awk '{print $1}' | tr -d '\r')
+    append_csv_row "$HASH_FILE" "$pkg,$apk_path,${hash:-N/A}"
+    ((count++))
+done < "$APK_LIST"
 
-# Steps
-run_step "$SCRIPT_DIR/steps/generate_apk_list.sh" \
-    "$DEVICE_OUT/reports/apk_list.csv" "Package,APK_Path"
-
-run_step "$SCRIPT_DIR/steps/generate_apk_metadata.sh" \
-    "$DEVICE_OUT/reports/apk_metadata.csv" "Package,Version,MinSDK,TargetSDK,SizeBytes,Permissions"
-
-run_step "$SCRIPT_DIR/steps/generate_apk_hashes.sh" \
-    "$DEVICE_OUT/reports/apk_hashes.csv" "Package,APK_Path,SHA256"
-
-run_step "$SCRIPT_DIR/steps/generate_running_apps.sh" \
-    "$DEVICE_OUT/reports/running_apps.csv" "Package,PID"
-
-run_step "$SCRIPT_DIR/find_social_apps.sh" \
-    "$DEVICE_OUT/reports/social_apps_found.csv" "Package,APK_Path,InstallType,Detected,Family,Confidence,SHA256,SourceCommand"
-
-run_step "$SCRIPT_DIR/find_motorola_apps.sh" \
-    "$DEVICE_OUT/reports/motorola_apps.csv" "Package,APK_Path"
-
-run_step "$SCRIPT_DIR/steps/generate_manifest.sh" "" "" --log "$LOG_FILE" --summary "$SUMMARY_FILE"
-
-status_ok "Full scan complete. Reports saved to $DEVICE_OUT"
+validate_csv "$HASH_FILE" "Package,APK_Path,SHA256"
+status_ok "Wrote hashes for $count packages to $HASH_FILE"

--- a/utils/display/menu.sh
+++ b/utils/display/menu.sh
@@ -3,12 +3,17 @@
 # Purpose: Menu rendering helpers with back-compat aliases
 
 # Back-compat aliases
-show_menu_header() { _menu_header; }
+show_menu_header() { _menu_header "$@"; }
 show_menu_option() { _menu_option "$@"; }
 show_menu_footer() { _menu_footer; }
 
 _menu_header() {
+  local device="$1"
   echo -e "${CYAN}${BOLD}┌──────────────── Android Tool Menu ────────────────┐${RESET}"
+  if [[ -n "$device" ]]; then
+    printf "${CYAN}${BOLD}│${RESET} Device: ${WHITE}%s${RESET}\n" "$device"
+    echo -e "${CYAN}${BOLD}├───────────────────────────────────────────────────┤${RESET}"
+  fi
 }
 _menu_option() {
   local num="$1"; shift
@@ -21,7 +26,7 @@ _menu_footer() {
 }
 
 print_menu() {
-  _menu_header
+  _menu_header "$1"
   _menu_option 1 "📦 List all APKs"
   _menu_option 2 "🌐 Scan social apps"
   _menu_option 3 "📱 List Motorola apps"


### PR DESCRIPTION
## Summary
- make `run.sh` the entry point with pre-run command checks and default interactive menu
- add similar checks and status logging in `main_menu.sh`
- ensure `generate_apk_hashes.sh` verifies required tools before hashing

## Testing
- `shellcheck -x run.sh main_menu.sh utils/display/menu.sh steps/generate_apk_hashes.sh`
- `bash -n run.sh main_menu.sh utils/display/menu.sh steps/generate_apk_hashes.sh`
- `bash run.sh --menu <<<"0"` *(fails: Missing required command: adb)*
- `bash steps/generate_apk_hashes.sh --device dummy --out tmp/test` *(fails: Missing required command: adb)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bba043748327a203e8992755b1a2