### PR TITLE
Handle detector outputs relative to run root

### DIFF
--- a/find_motorola_apps.sh
+++ b/find_motorola_apps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script: find_motorola_apps.sh
 # Purpose: Generate report of Motorola packages for a connected device.
-# Output: <out_dir>/motorola_apps.csv
+# Output: <run_dir>/reports/motorola_apps.csv
 
 set -euo pipefail
 
@@ -40,19 +40,21 @@ fi
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-# Resolve output directory
-if [[ -n "$OUT_ARG" ]]; then
-    DEVICE_OUT="$OUT_ARG"
-else
-    DEVICE_OUT="$OUTDIR/$DEVICE/reports"
-fi
-mkdir -p "$DEVICE_OUT"
+# Resolve output directory (run root)
+ROOT_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$ROOT_OUT/reports"
+mkdir -p "$REPORT_DIR"
 
-APK_LIST_FILE="$DEVICE_OUT/apk_list.csv"
-MOTO_FILE="$DEVICE_OUT/motorola_apps.csv"
+APK_LIST_FILE="$REPORT_DIR/apk_list.csv"
+MOTO_FILE="$REPORT_DIR/motorola_apps.csv"
+
+if [[ ! -f "$APK_LIST_FILE" ]]; then
+    status_error "Required APK list not found: $APK_LIST_FILE"
+    exit 1
+fi
 
 status_info "Scanning for Motorola packages on device: $DEVICE"
-TMP_FILE=$(mktemp "$DEVICE_OUT/tmp.XXXXXX")
+TMP_FILE=$(mktemp "$REPORT_DIR/tmp.XXXXXX")
 count=0
 
 while IFS=, read -r pkg apk_path; do

--- a/find_social_apps.sh
+++ b/find_social_apps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script: find_social_apps.sh
 # Purpose: Generate social app report for a connected device.
-# Outputs: <out_dir>/social_apps_found.csv
+# Outputs: <run_dir>/reports/social_apps_found.csv
 
 set -euo pipefail
 
@@ -39,18 +39,20 @@ fi
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
 
-# Resolve output directory
-if [[ -n "$OUT_ARG" ]]; then
-    DEVICE_OUT="$OUT_ARG"
-else
-    DEVICE_OUT="$OUTDIR/$DEVICE/reports"
-fi
-mkdir -p "$DEVICE_OUT"
+# Resolve output directory (run root)
+ROOT_OUT="${OUT_ARG:-$OUTDIR/$DEVICE}"
+REPORT_DIR="$ROOT_OUT/reports"
+mkdir -p "$REPORT_DIR"
 
-APK_LIST_FILE="$DEVICE_OUT/apk_list.csv"
-HASH_FILE="$DEVICE_OUT/apk_hashes.csv"
-SOCIAL_FILE="$DEVICE_OUT/social_apps_found.csv"
+APK_LIST_FILE="$REPORT_DIR/apk_list.csv"
+HASH_FILE="$REPORT_DIR/apk_hashes.csv"
+SOCIAL_FILE="$REPORT_DIR/social_apps_found.csv"
 SOURCE_CMD="adb -s $DEVICE shell pm list packages -f"
+
+if [[ ! -f "$APK_LIST_FILE" ]]; then
+    status_error "Required APK list not found: $APK_LIST_FILE"
+    exit 1
+fi
 
 status_info "Scanning for social apps on device: $DEVICE"
 status_info "Using APK list: $APK_LIST_FILE"
@@ -91,7 +93,7 @@ get_family() {
     esac
 }
 
-TMP_FILE=$(mktemp "$DEVICE_OUT/tmp.XXXXXX")
+TMP_FILE=$(mktemp "$REPORT_DIR/tmp.XXXXXX")
 count=0
 exact_count=0
 preload_count=0


### PR DESCRIPTION
## Summary
- Ensure `find_social_apps.sh` and `find_motorola_apps.sh` treat `--out` as the run root and write reports under `<run>/reports`
- Add validation for missing `apk_list.csv` inputs

## Testing
- `shellcheck -x find_social_apps.sh find_motorola_apps.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8c82facbc8327ab2cf214feba5f42