### PR TITLE
Add ADB device state validation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ source "$SCRIPT_DIR/list_devices.sh"
 source "$SCRIPT_DIR/utils/display/base.sh"
 source "$SCRIPT_DIR/utils/display/status.sh"
 source "$SCRIPT_DIR/utils/validate_csv.sh"
+source "$SCRIPT_DIR/utils/device_utils.sh"
 
 usage() {
     echo "Usage: $0 [-d DEVICE] [--menu]" >&2
@@ -61,6 +62,7 @@ fi
 
 DEVICE=$(list_devices "$DEVICE_ARG") || exit 1
 adb -s "$DEVICE" wait-for-device >/dev/null 2>&1
+ensure_device_state "$DEVICE"
 
 # Timestamped run directory
 RUN_TS=$(date +%Y%m%d_%H%M%S)

--- a/utils/device_utils.sh
+++ b/utils/device_utils.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Library: device_utils.sh
+# Provides helper functions for adb device readiness checks
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils/display/base.sh
+source "$SCRIPT_DIR/display/base.sh"
+# shellcheck source=utils/display/status.sh
+source "$SCRIPT_DIR/display/status.sh"
+
+# ensure_device_state SERIAL
+# Verifies that the given device is in the 'device' state.
+# Prints an error and returns non-zero if not.
+ensure_device_state() {
+    local dev="$1"
+    local state
+    state="$(adb -s "$dev" get-state 2>/dev/null || echo unknown)"
+    if [[ "$state" != "device" ]]; then
+        status_error "Device $dev not ready (state: $state)"
+        return 1
+    fi
+}


### PR DESCRIPTION
## Summary
- Ensure run.sh verifies ADB device readiness after waiting for device
- Introduce reusable `ensure_device_state` helper for checking device state

## Testing
- `shellcheck run.sh utils/device_utils.sh`
- `./run.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd705fac83278c3e0a6a32584de1