### PR TITLE
Add validation for blank Package entries

### DIFF
--- a/apk_actions.sh
+++ b/apk_actions.sh
@@ -74,7 +74,7 @@ hash_apks() {
     done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
     if command -v validate_csv >/dev/null 2>&1; then
-        validate_csv "$MANIFEST" "Package,APK_Path,SHA256"
+        validate_csv "$MANIFEST" "Package,APK_Path,SHA256" || return 1
     fi
     log_info "Hashed $count APKs → $MANIFEST"
 }
@@ -96,7 +96,7 @@ apk_metadata() {
         ((count++))
     done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
-    validate_csv "$METADATAFILE" "Package,Version,Permissions"
+    validate_csv "$METADATAFILE" "Package,Version,Permissions" || return 1
     log_info "Metadata saved for $count packages → $METADATAFILE"
 }
 
@@ -118,6 +118,6 @@ running_processes() {
         fi
     done < <(tail -n +2 "$DEVICE_OUT/apk_list.csv")
 
-    validate_csv "$RUNNINGFILE" "Package,PID"
+    validate_csv "$RUNNINGFILE" "Package,PID" || return 1
     log_info "Logged $count running apps → $RUNNINGFILE"
 }

--- a/main_menu.sh
+++ b/main_menu.sh
@@ -48,7 +48,7 @@ run_step() {
   status_info "Running $(basename "$script")"
   "$SCRIPT_DIR/$script" --device "$DEVICE" --out "$OUT_DIR" "$@"
   if [[ -n "$csv" && -n "$header" ]]; then
-    validate_csv "$csv" "$header"
+    validate_csv "$csv" "$header" || return 1
   fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -88,7 +88,7 @@ run_step() {
     status_info "Running $(basename "$script")"
     "$script" --device "$DEVICE" --out "$DEVICE_OUT" "$@"
     if [[ -n "$csv" && -n "$header" ]]; then
-        validate_csv "$csv" "$header"
+        validate_csv "$csv" "$header" || return 1
     fi
 }
 

--- a/utils/validate_csv.sh
+++ b/utils/validate_csv.sh
@@ -15,8 +15,12 @@ validate_csv() {
         echo "validate_csv: header mismatch in $file" >&2
         return 1
     fi
-    awk -F, 'NR==2{prev=tolower($1);next} NR>2{cur=tolower($1); if(cur<prev){exit 1} prev=cur}' "$file" || {
+    awk -F, 'NR>1 {if($1=="") next; cur=tolower($1); if(prev && cur<prev){exit 1}; prev=cur}' "$file" || {
         echo "validate_csv: Package column not sorted in $file" >&2
+        return 1
+    }
+    awk -F, 'NR>1 && $1=="" {exit 1}' "$file" || {
+        echo "validate_csv: blank Package in $file" >&2
         return 1
     }
 }


### PR DESCRIPTION
## Summary
- fail validation when a CSV row has a blank Package field
- propagate validation failures to callers
- ignore blank Package rows during sorting so the proper error is raised

## Testing
- `shellcheck utils/validate_csv.sh apk_actions.sh run.sh main_menu.sh`
- `validate_csv tmp_test/good.csv "Package,APK_Path,SHA256" && echo good ok`
- `validate_csv tmp_test/bad.csv "Package,APK_Path,SHA256" && echo bad ok || echo bad fail`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd65b50c8327bbecd1c58baa572c